### PR TITLE
Add changes for node v10

### DIFF
--- a/bin/update-changelog.js
+++ b/bin/update-changelog.js
@@ -169,7 +169,7 @@ function prependToChangelog(str) {
   const buffer = Buffer.from(str);
   fs.writeSync(fd, buffer, 0, buffer.length); // Write new data
   fs.writeSync(fd, data, 0, data.length); // Append old data
-  fs.close(fd);
+  fs.closeSync(fd);
 }
 
 getPullRequests((pullRequests) => {

--- a/bin/update-changelog.js
+++ b/bin/update-changelog.js
@@ -158,7 +158,7 @@ function stringifyPullRequests(pullRequests) {
 }
 
 function prependToChangelog(str) {
-  let data = new Buffer('');
+  let data = Buffer.from('');
   try {
     data = fs.readFileSync(changelogPath); // Read existing contents into data
   } catch (error) {
@@ -166,7 +166,7 @@ function prependToChangelog(str) {
   }
 
   const fd = fs.openSync(changelogPath, 'w+');
-  const buffer = new Buffer(str);
+  const buffer = Buffer.from(str);
   fs.writeSync(fd, buffer, 0, buffer.length); // Write new data
   fs.writeSync(fd, data, 0, data.length); // Append old data
   fs.close(fd);


### PR DESCRIPTION
When using release module with node v10 some functions need adjusting in update-changelog step:
- using Buffer builder instead of constructor
- using synchronuous fs.close when no callback provided